### PR TITLE
Fix PayStatus reflecting wrong colour on UI

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UnpayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnpayCommand.java
@@ -64,7 +64,7 @@ public class UnpayCommand extends Command {
             List<Person> lastShownList = model.getFilteredPersonList();
             for (Person person : lastShownList) {
                 Person unpaidPerson = new Person(person.getName(), person.getPhone(), person.getEmail(),
-                        person.getAddress(), person.getNextLesson(), new PayStatus("UNPAID"), person.getSubjects());
+                        person.getAddress(), person.getNextLesson(), new PayStatus("NOT_PAID"), person.getSubjects());
                 model.setPerson(person, unpaidPerson);
             }
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -47,7 +47,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-        PayStatus payStatus = new PayStatus(PayStatus.UNPAID);
+        PayStatus payStatus = new PayStatus(PayStatus.NOT_PAID);
         NextLesson nextLesson = new NextLesson();
         Set<Subject> subjectList = ParserUtil.parseSubjects(argMultimap.getAllValues(PREFIX_SUBJECT));
 

--- a/src/main/java/seedu/address/model/person/PayStatus.java
+++ b/src/main/java/seedu/address/model/person/PayStatus.java
@@ -8,7 +8,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class PayStatus {
     public static final String PAID = "PAID";
-    public static final String UNPAID = "UNPAID";
+    public static final String NOT_PAID = "NOT PAID";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -21,27 +21,27 @@ import seedu.address.model.subject.Subject;
 public class SampleDataUtil {
 
     public static final NextLesson EMPTY_NEXTLESSON = new NextLesson();
-    public static final PayStatus UNPAID_PAYSTATUS = new PayStatus(PayStatus.UNPAID);
+    public static final PayStatus EMPTY_PAYSTATUS = new PayStatus("");
 
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"), EMPTY_NEXTLESSON, UNPAID_PAYSTATUS,
+                new Address("Blk 30 Geylang Street 29, #06-40"), EMPTY_NEXTLESSON, EMPTY_PAYSTATUS,
                 getSubjectSet("math")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), EMPTY_NEXTLESSON, UNPAID_PAYSTATUS,
+                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), EMPTY_NEXTLESSON, EMPTY_PAYSTATUS,
                 getSubjectSet("math", "chemistry")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), EMPTY_NEXTLESSON, UNPAID_PAYSTATUS,
+                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), EMPTY_NEXTLESSON, EMPTY_PAYSTATUS,
                 getSubjectSet("physics")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), EMPTY_NEXTLESSON, UNPAID_PAYSTATUS,
+                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), EMPTY_NEXTLESSON, EMPTY_PAYSTATUS,
                 getSubjectSet("math")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"), EMPTY_NEXTLESSON, UNPAID_PAYSTATUS,
+                new Address("Blk 47 Tampines Street 20, #17-35"), EMPTY_NEXTLESSON, EMPTY_PAYSTATUS,
                 getSubjectSet("math")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"), EMPTY_NEXTLESSON, UNPAID_PAYSTATUS,
+                new Address("Blk 45 Aljunied Street 85, #11-31"), EMPTY_NEXTLESSON, EMPTY_PAYSTATUS,
                 getSubjectSet("biology"))
         };
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -40,7 +40,7 @@ public class CommandTestUtil {
     public static final String VALID_NEXTLESSON_AMY = "13/04/2025 0900-1100";
     public static final String VALID_NEXTLESSON_BOB = "15/04/2025 1700-1900";
     public static final String VALID_PAYSTATUS_AMY = PayStatus.PAID;
-    public static final String VALID_PAYSTATUS_BOB = PayStatus.UNPAID;
+    public static final String VALID_PAYSTATUS_BOB = PayStatus.NOT_PAID;
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/model/person/PayStatusTest.java
+++ b/src/test/java/seedu/address/model/person/PayStatusTest.java
@@ -12,7 +12,7 @@ public class PayStatusTest {
     public void equals() {
         final PayStatus payStatus = new PayStatus(PayStatus.PAID);
         final PayStatus samePayStatus = new PayStatus(PayStatus.PAID);
-        final PayStatus differentPayStatus = new PayStatus(PayStatus.UNPAID);
+        final PayStatus differentPayStatus = new PayStatus(PayStatus.NOT_PAID);
 
         // same object -> returns true
         assertTrue(payStatus.equals(payStatus));

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -25,7 +25,7 @@ public class PersonBuilder {
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final String DEFAULT_NEXT_LESSON = "15/04/2025 1900-2100";
-    public static final String DEFAULT_PAYSTATUS = PayStatus.UNPAID;
+    public static final String DEFAULT_PAYSTATUS = "";
 
     private Name name;
     private Phone phone;


### PR DESCRIPTION
This PR fixes an unintentional bug introduced from #119, where the default pay status (NOT PAID) was reflected as _green_ instead of _red_.

Fixes #127 