### PR TITLE
Phone fix

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -61,6 +61,8 @@ public class ParserUtil {
         String trimmedPhone = phone.trim();
         if (!Phone.isValidPhone(trimmedPhone)) {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
+        } else if (!Phone.isValidLength(trimmedPhone)) {
+            throw new ParseException(Phone.LENGTH_CONSTRAINTS);
         }
         return new Phone(trimmedPhone);
     }

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -15,6 +15,8 @@ public class Phone {
     public static final String LENGTH_CONSTRAINTS =
             "The phone number is invalid as it is too long. "
                     + "Please ensure that you are entering a valid phone number. ";
+    // E.164 standard states that a phone number can be up to 15 digits long.
+    public static final Integer MAX_LENGTH = 15;
     public static final String VALIDATION_REGEX = "\\d{3,}";
     public final String value;
 
@@ -40,12 +42,11 @@ public class Phone {
 
     /**
      * Returns true if a given string is less than 16 characters long.
-     * E.164 standard states that a phone number can be up to 15 digits long.
      * This method should be used alongside {@link #isValidPhone(String)} to ensure that the phone number is valid.
      */
     public static boolean isValidLength(String test) {
 
-        return test.length() < 16;
+        return test.length() <= MAX_LENGTH;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -12,6 +12,9 @@ public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers, and it should be at least 3 digits long";
+    public static final String LENGTH_CONSTRAINTS =
+            "The phone number is invalid as it is too long. "
+                    + "Please ensure that you are entering a valid phone number. ";
     public static final String VALIDATION_REGEX = "\\d{3,}";
     public final String value;
 
@@ -23,6 +26,7 @@ public class Phone {
     public Phone(String phone) {
         requireNonNull(phone);
         checkArgument(isValidPhone(phone), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidLength(phone), LENGTH_CONSTRAINTS);
         value = phone;
     }
 
@@ -30,7 +34,18 @@ public class Phone {
      * Returns true if a given string is a valid phone number.
      */
     public static boolean isValidPhone(String test) {
+
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a given string is less than 16 characters long.
+     * E.164 standard states that a phone number can be up to 15 digits long.
+     * This method should be used alongside {@link #isValidPhone(String)} to ensure that the phone number is valid.
+     */
+    public static boolean isValidLength(String test) {
+
+        return test.length() < 16;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -22,7 +22,8 @@ import seedu.address.model.subject.Subject;
 
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_PHONE_1 = "+651234";
+    private static final String INVALID_PHONE_2 = "1234567890123456";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_SUBJECT = "#math";
@@ -86,7 +87,7 @@ public class ParserUtilTest {
 
     @Test
     public void parsePhone_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parsePhone(INVALID_PHONE));
+        assertThrows(ParseException.class, () -> ParserUtil.parsePhone(INVALID_PHONE_1));
     }
 
     @Test
@@ -100,6 +101,11 @@ public class ParserUtilTest {
         String phoneWithWhitespace = WHITESPACE + VALID_PHONE + WHITESPACE;
         Phone expectedPhone = new Phone(VALID_PHONE);
         assertEquals(expectedPhone, ParserUtil.parsePhone(phoneWithWhitespace));
+    }
+
+    @Test
+    public void parsePhone_invalidLength_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePhone(INVALID_PHONE_2));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -39,6 +39,18 @@ public class PhoneTest {
     }
 
     @Test
+    public void isValidLength() {
+        // null phone number
+        assertThrows(NullPointerException.class, () -> Phone.isValidLength(null));
+
+        // invalid phone number
+        assertFalse(Phone.isValidLength("1234567890123456")); // more than 15 digits
+
+        // valid phone number
+        assertTrue(Phone.isValidLength("123456789012345")); // 15 digits
+    }
+
+    @Test
     public void equals() {
         Phone phone = new Phone("999");
 


### PR DESCRIPTION
This PR ensures that phone numbers do not go past 15 characters, as such numbers are invalid in the real world.

Fixes #137 