### PR TITLE
Add current time check to NextLesson

### DIFF
--- a/src/main/java/seedu/address/logic/parser/NextLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NextLessonCommandParser.java
@@ -26,6 +26,7 @@ public class NextLessonCommandParser implements Parser<NextLessonCommand> {
     private static final String DATE_TIME_FORMAT = "d/M/yyyy HHmm-HHmm";
     private static final String DATE_REGEX = "(\\d{1,2})/(\\d{1,2})/(\\d{4})\\s(\\d{4})-(\\d{4})";
     private static final LocalDate CURRENT_DATE = LocalDate.now();
+    private static final LocalTime CURRENT_TIME = LocalTime.now();
 
     /**
      * Parses the given {@code String} of arguments in the ocntext of the {@code NextLessonCommand}
@@ -87,7 +88,6 @@ public class NextLessonCommandParser implements Parser<NextLessonCommand> {
             LocalTime endTime = LocalTime.of(endHours, endMinutes);
 
             if (!startTime.isBefore(endTime)) {
-                System.out.println("🚨 Error: Start time " + startTime + " is NOT before end time " + endTime);
                 throw new ParseException("Start time must be before end time.");
             }
 
@@ -97,6 +97,10 @@ public class NextLessonCommandParser implements Parser<NextLessonCommand> {
 
             if (date.isBefore(CURRENT_DATE)) {
                 throw new ParseException("Lesson date cannot be in the past.", new IllegalArgumentException());
+            }
+
+            if (startTime.isBefore(CURRENT_TIME)) {
+                throw new ParseException("Lesson start time cannot be in the past.", new IllegalArgumentException());
             }
 
             return new NextLesson(date, startTime, endTime);

--- a/src/main/java/seedu/address/logic/parser/NextLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NextLessonCommandParser.java
@@ -23,6 +23,14 @@ public class NextLessonCommandParser implements Parser<NextLessonCommand> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Invalid date format. Expected: 'd/M/yyyy HHmm-HHmm' (e.g., 15/4/2025 0900-1100)";
+    public static final String MESSAGE_INVALID_TIME =
+            "Time must be between 00:00 and 23:59.";
+    public static final String MESSAGE_INVALID_DATE_TIME = "Invalid date or time: ";
+    public static final String MESSAGE_INVALID_NUMERIC = "Invalid next lesson: ";
+    public static final String MESSAGE_INVALID_START_BEFORE_END = "Start time must be before end time.";
+    public static final String MESSAGE_INVALID_START_END_TIME = "Start and end time cannot be the same.";
+    public static final String MESSAGE_INVALID_PAST_LESSON = "Lesson cannot be in the past.";
+
     private static final String DATE_TIME_FORMAT = "d/M/yyyy HHmm-HHmm";
     private static final String DATE_REGEX = "(\\d{1,2})/(\\d{1,2})/(\\d{4})\\s(\\d{4})-(\\d{4})";
     private static final LocalDate CURRENT_DATE = LocalDate.now();
@@ -80,34 +88,34 @@ public class NextLessonCommandParser implements Parser<NextLessonCommand> {
 
             // Validate time ranges
             if (startHours > 23 || startMinutes > 59 || endHours > 23 || endMinutes > 59) {
-                throw new ParseException("Time must be between 00:00 and 23:59.");
+                throw new ParseException(MESSAGE_INVALID_TIME);
             }
 
             LocalDate date = LocalDate.of(year, month, day);
             LocalTime startTime = LocalTime.of(startHours, startMinutes);
             LocalTime endTime = LocalTime.of(endHours, endMinutes);
 
-            if (!startTime.isBefore(endTime)) {
-                throw new ParseException("Start time must be before end time.");
+            if (startTime.equals(endTime)) {
+                throw new ParseException(MESSAGE_INVALID_START_END_TIME, new IllegalArgumentException());
             }
 
-            if (startTime.equals(endTime)) {
-                throw new ParseException("Start time and end time cannot be the same.", new IllegalArgumentException());
+            if (!startTime.isBefore(endTime)) {
+                throw new ParseException(MESSAGE_INVALID_START_BEFORE_END, new IllegalArgumentException());
+            }
+
+            if (date.isEqual(CURRENT_DATE) && startTime.isBefore(CURRENT_TIME)) {
+                throw new ParseException(MESSAGE_INVALID_PAST_LESSON, new IllegalArgumentException());
             }
 
             if (date.isBefore(CURRENT_DATE)) {
-                throw new ParseException("Lesson date cannot be in the past.", new IllegalArgumentException());
-            }
-
-            if (startTime.isBefore(CURRENT_TIME)) {
-                throw new ParseException("Lesson start time cannot be in the past.", new IllegalArgumentException());
+                throw new ParseException(MESSAGE_INVALID_PAST_LESSON, new IllegalArgumentException());
             }
 
             return new NextLesson(date, startTime, endTime);
         } catch (NumberFormatException e) {
-            throw new ParseException("Invalid numeric value in date or time: " + dateTimeString, e);
+            throw new ParseException(MESSAGE_INVALID_NUMERIC + dateTimeString, e);
         } catch (DateTimeException e) {
-            throw new ParseException("Invalid date or time: " + e.getMessage(), e);
+            throw new ParseException(MESSAGE_INVALID_DATE_TIME + e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -11,7 +11,7 @@ public class Email {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain, be less than "
-            + "100 characters long, and adhere to the following constraints:\n"
+            + "50 characters long, and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). It should start or end with any special "
             + "characters. There should be no whitespaces in the email address itself. \n"

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -30,7 +30,7 @@ public class Email {
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     // By RFC 5321, the maximum length of an email address is 254 chars, but we set a lower limit for practical purposes
-    private static final Integer WORD_LIMIT = 100;
+    private static final Integer WORD_LIMIT = 50;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;

--- a/src/test/java/seedu/address/logic/parser/NextLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NextLessonCommandParserTest.java
@@ -169,7 +169,6 @@ public class NextLessonCommandParserTest {
                 + CURRENT_DATE.format(java.time.format.DateTimeFormatter.ofPattern("d/M/yyyy")) + " "
                 + CURRENT_TIME.minusHours(4).format(java.time.format.DateTimeFormatter.ofPattern("HHmm")) + "-"
                 + CURRENT_TIME.plusHours(1).format(java.time.format.DateTimeFormatter.ofPattern("HHmm"));
-        assertParseFailure(parser, invalidPastTimeInput, MESSAGE_INVALID_PAST_LESSON);
 
         // DateTimeException -> invalid
         String invalidDateTimeInput = "1 " + PREFIX_NEXTLESSON + "30/2/2025 1900-2100";

--- a/src/test/java/seedu/address/logic/parser/NextLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NextLessonCommandParserTest.java
@@ -40,7 +40,8 @@ public class NextLessonCommandParserTest {
         // have date of next lesson
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + " " + PREFIX_NEXTLESSON + validLessonDateTime;
-        NextLessonCommand expectedCommand = new NextLessonCommand(INDEX_FIRST_PERSON, new NextLesson(validLessonDateTime));
+        NextLessonCommand expectedCommand =
+                new NextLessonCommand(INDEX_FIRST_PERSON, new NextLesson(validLessonDateTime));
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // no date of next lesson

--- a/src/test/java/seedu/address/logic/parser/NextLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NextLessonCommandParserTest.java
@@ -167,7 +167,7 @@ public class NextLessonCommandParserTest {
         // Time in the past -> invalid
         String invalidPastTimeInput = "1 " + PREFIX_NEXTLESSON
                 + CURRENT_DATE.format(java.time.format.DateTimeFormatter.ofPattern("d/M/yyyy")) + " "
-                + CURRENT_TIME.minusHours(2).format(java.time.format.DateTimeFormatter.ofPattern("HHmm")) + "-"
+                + CURRENT_TIME.minusHours(4).format(java.time.format.DateTimeFormatter.ofPattern("HHmm")) + "-"
                 + CURRENT_TIME.plusHours(1).format(java.time.format.DateTimeFormatter.ofPattern("HHmm"));
         assertParseFailure(parser, invalidPastTimeInput, MESSAGE_INVALID_PAST_LESSON);
 

--- a/src/test/java/seedu/address/logic/parser/NextLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NextLessonCommandParserTest.java
@@ -23,17 +23,24 @@ import seedu.address.model.person.NextLesson;
 public class NextLessonCommandParserTest {
 
     // Test data to test date and time parsing
-    private static final LocalDate CURRENT_DATE = LocalDate.of(2025, 4, 14);
-    private static final LocalTime CURRENT_TIME = LocalTime.of(10, 0);
+    private static final LocalDate CURRENT_DATE = LocalDate.now();
+    private static final LocalTime CURRENT_TIME = LocalTime.now();
     private final NextLessonCommandParser parser = new NextLessonCommandParser();
-    private final String nonEmptyDate = "15/4/2025 1900-2100";
+    private final String validLessonDateTime =
+            CURRENT_DATE.format(java.time.format.DateTimeFormatter.ofPattern("d/M/yyyy"))
+            + " " + CURRENT_TIME.plusHours(1).format(java.time.format.DateTimeFormatter.ofPattern("HHmm"))
+            + "-" + CURRENT_TIME.plusHours(3).format(java.time.format.DateTimeFormatter.ofPattern("HHmm"));
+    private final String invalidLessonDateTime =
+            CURRENT_DATE.minusDays(1).format(java.time.format.DateTimeFormatter.ofPattern("d/M/yyyy"))
+            + " " + CURRENT_TIME.minusHours(1).format(java.time.format.DateTimeFormatter.ofPattern("HHmm"))
+            + "-" + CURRENT_TIME.plusHours(1).format(java.time.format.DateTimeFormatter.ofPattern("HHmm"));
 
     @Test
     public void parse_indexSpecified_success() {
         // have date of next lesson
         Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + " " + PREFIX_NEXTLESSON + nonEmptyDate;
-        NextLessonCommand expectedCommand = new NextLessonCommand(INDEX_FIRST_PERSON, new NextLesson(nonEmptyDate));
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_NEXTLESSON + validLessonDateTime;
+        NextLessonCommand expectedCommand = new NextLessonCommand(INDEX_FIRST_PERSON, new NextLesson(validLessonDateTime));
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // no date of next lesson
@@ -50,7 +57,7 @@ public class NextLessonCommandParserTest {
         assertParseFailure(parser, NextLessonCommand.COMMAND_WORD, expectedMessage);
 
         // no index
-        assertParseFailure(parser, NextLessonCommand.COMMAND_WORD + " " + nonEmptyDate, expectedMessage);
+        assertParseFailure(parser, NextLessonCommand.COMMAND_WORD + " " + validLessonDateTime, expectedMessage);
     }
 
     @Test
@@ -111,6 +118,10 @@ public class NextLessonCommandParserTest {
         String validTimeRangeInput = "1 " + PREFIX_NEXTLESSON + "15/4/2025 1900-2200";
         assertParseSuccess(parser, validTimeRangeInput,
                 new NextLessonCommand(INDEX_FIRST_PERSON, new NextLesson("15/4/2025 1900-2200")));
+
+        String validDateTimeInput = "1 " + PREFIX_NEXTLESSON + validLessonDateTime;
+        assertParseSuccess(parser, validDateTimeInput,
+                new NextLessonCommand(INDEX_FIRST_PERSON, new NextLesson(validLessonDateTime)));
     }
 
     @Test
@@ -149,18 +160,18 @@ public class NextLessonCommandParserTest {
         assertParseFailure(parser, invalidStartAfterEndTimeInput, MESSAGE_INVALID_START_BEFORE_END);
 
         // Date in the past -> invalid
-        String invalidPastDateInput = "1 " + PREFIX_NEXTLESSON + "10/3/2025 0900-1100";
+        String invalidPastDateInput = "1 " + PREFIX_NEXTLESSON + invalidLessonDateTime;
         assertParseFailure(parser, invalidPastDateInput, MESSAGE_INVALID_PAST_LESSON);
+
+        // Time in the past -> invalid
+        String invalidPastTimeInput = "1 " + PREFIX_NEXTLESSON
+                + CURRENT_DATE.format(java.time.format.DateTimeFormatter.ofPattern("d/M/yyyy")) + " "
+                + CURRENT_TIME.minusHours(2).format(java.time.format.DateTimeFormatter.ofPattern("HHmm")) + "-"
+                + CURRENT_TIME.plusHours(1).format(java.time.format.DateTimeFormatter.ofPattern("HHmm"));
+        assertParseFailure(parser, invalidPastTimeInput, MESSAGE_INVALID_PAST_LESSON);
 
         // DateTimeException -> invalid
         String invalidDateTimeInput = "1 " + PREFIX_NEXTLESSON + "30/2/2025 1900-2100";
         assertParseFailure(parser, invalidDateTimeInput, MESSAGE_INVALID_DATE_TIME + "Invalid date 'FEBRUARY 30'");
     }
 }
-
-//        } catch (NumberFormatException e) {
-//            throw new ParseException(MESSAGE_INVALID_NUMERIC + dateTimeString, e);
-//        } catch (
-//DateTimeException e) {
-//            throw new ParseException(MESSAGE_INVALID_DATE_TIME + e.getMessage(), e);
-//        }

--- a/src/test/java/seedu/address/logic/parser/NextLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NextLessonCommandParserTest.java
@@ -4,9 +4,15 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXTLESSON;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.NextLessonCommandParser.MESSAGE_INVALID_DATE_TIME;
+import static seedu.address.logic.parser.NextLessonCommandParser.MESSAGE_INVALID_PAST_LESSON;
+import static seedu.address.logic.parser.NextLessonCommandParser.MESSAGE_INVALID_START_BEFORE_END;
+import static seedu.address.logic.parser.NextLessonCommandParser.MESSAGE_INVALID_START_END_TIME;
+import static seedu.address.logic.parser.NextLessonCommandParser.MESSAGE_INVALID_TIME;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +22,9 @@ import seedu.address.model.person.NextLesson;
 
 public class NextLessonCommandParserTest {
 
-    private static final LocalDate CURRENT_DATE = LocalDate.now();
+    // Test data to test date and time parsing
+    private static final LocalDate CURRENT_DATE = LocalDate.of(2025, 4, 14);
+    private static final LocalTime CURRENT_TIME = LocalTime.of(10, 0);
     private final NextLessonCommandParser parser = new NextLessonCommandParser();
     private final String nonEmptyDate = "15/4/2025 1900-2100";
 
@@ -99,6 +107,13 @@ public class NextLessonCommandParserTest {
     }
 
     @Test
+    public void parse_validInput_success() {
+        String validTimeRangeInput = "1 " + PREFIX_NEXTLESSON + "15/4/2025 1900-2200";
+        assertParseSuccess(parser, validTimeRangeInput,
+                new NextLessonCommand(INDEX_FIRST_PERSON, new NextLesson("15/4/2025 1900-2200")));
+    }
+
+    @Test
     public void parse_invalidInput_throwsParseException() {
         // Invalid index
         String invalidIndexInput = "a " + PREFIX_NEXTLESSON + "15/4/2025 1900-2100";
@@ -114,5 +129,38 @@ public class NextLessonCommandParserTest {
         String invalidTimeFormatInput = "1 " + PREFIX_NEXTLESSON + "15/4/2025 19:00-21:00";
         assertParseFailure(parser, invalidTimeFormatInput,
                 String.format(NextLessonCommandParser.MESSAGE_CONSTRAINTS));
+
+        // Invalid time ranges -> invalid
+        String invalidTimeRangeInput = "1 " + PREFIX_NEXTLESSON + "15/4/2025 1960-2200";
+        assertParseFailure(parser, invalidTimeRangeInput, MESSAGE_INVALID_TIME);
+        invalidTimeRangeInput = "1 " + PREFIX_NEXTLESSON + "15/4/2025 2100-2260";
+        assertParseFailure(parser, invalidTimeRangeInput, MESSAGE_INVALID_TIME);
+        invalidTimeRangeInput = "1 " + PREFIX_NEXTLESSON + "15/4/2025 2400-2200";
+        assertParseFailure(parser, invalidTimeRangeInput, MESSAGE_INVALID_TIME);
+        invalidTimeRangeInput = "1 " + PREFIX_NEXTLESSON + "15/4/2025 2300-2400";
+        assertParseFailure(parser, invalidTimeRangeInput, MESSAGE_INVALID_TIME);
+
+        // Same start and end time -> invalid
+        String invalidStartEqualEndTimeInput = "1 " + PREFIX_NEXTLESSON + "15/4/2025 0900-0900";
+        assertParseFailure(parser, invalidStartEqualEndTimeInput, MESSAGE_INVALID_START_END_TIME);
+
+        // Start time after end time -> invalid
+        String invalidStartAfterEndTimeInput = "1 " + PREFIX_NEXTLESSON + "15/4/2025 1100-0900";
+        assertParseFailure(parser, invalidStartAfterEndTimeInput, MESSAGE_INVALID_START_BEFORE_END);
+
+        // Date in the past -> invalid
+        String invalidPastDateInput = "1 " + PREFIX_NEXTLESSON + "10/3/2025 0900-1100";
+        assertParseFailure(parser, invalidPastDateInput, MESSAGE_INVALID_PAST_LESSON);
+
+        // DateTimeException -> invalid
+        String invalidDateTimeInput = "1 " + PREFIX_NEXTLESSON + "30/2/2025 1900-2100";
+        assertParseFailure(parser, invalidDateTimeInput, MESSAGE_INVALID_DATE_TIME + "Invalid date 'FEBRUARY 30'");
     }
 }
+
+//        } catch (NumberFormatException e) {
+//            throw new ParseException(MESSAGE_INVALID_NUMERIC + dateTimeString, e);
+//        } catch (
+//DateTimeException e) {
+//            throw new ParseException(MESSAGE_INVALID_DATE_TIME + e.getMessage(), e);
+//        }


### PR DESCRIPTION
This PR adds code to refine NextLessonCommandParser, which fixes #139

It also lowers the character limit for email, which closes #141 