### PR TITLE
Update invalid index message

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,7 +14,8 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The index provided is invalid!";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The index provided is invalid!\n" +
+            "The index should be a positive integer up to the number of the last person shown.";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,8 +14,8 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The index provided is invalid!\n" +
-            "The index should be a positive integer up to the number of the last person shown.";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The index provided is invalid!\n"
+            + "The index  should be a positive integer up to the number of the last person shown.";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,7 +15,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The index provided is invalid!\n"
-            + "The index  should be a positive integer up to the number of the last person shown.";
+            + "The index should be a positive integer up to the number of the last person shown.";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";


### PR DESCRIPTION
Updated invalid index message to be clearer on what's a valid index when index greater than number of persons shown is entered.

For index 0, ParserUtil::parseIndex throws a ParseException as it is a non-zero unsigned integer which shows the invalid command format error instead. Unable to find a fix that does not break the expected behaviour of ParserUtil::parseIndex function.

Partially fixes #125
Partially fixes #126 